### PR TITLE
Added options to allow the returning of an array of escaped arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ $ echo 'hello!' 'how are you doing $USER' '"double"' ''"'"'single'"'"''
 hello! how are you doing $USER "double" 'single'
 ```
 
+### Returning an array
+
+You can return an array suitable for use with Node.js child_process.spawn.
+
+```js
+var shellescape = require('shell-escape');
+var args = ['-la', '/tmp/my path'];
+
+var escaped = shellescape(args, {returnArray: true});
+console.log(escaped);
+```
+
+yields
+
+```
+[ '-la', '\'/tmp/my path\'' ]
+```
+
 License
 -------
 

--- a/shell-escape.js
+++ b/shell-escape.js
@@ -31,7 +31,8 @@ var escapechars = [
 module.exports = shellescape;
 
 // return a shell compatible format
-function shellescape(a) {
+function shellescape(a, options) {
+  options = typeof options !== 'undefined' ? options : {};
   var ret = [];
 
   a.forEach(function(s) {
@@ -49,5 +50,8 @@ function shellescape(a) {
     ret.push(s);
   });
 
+  if(options.returnArray == true){
+    return ret;
+  }
   return ret.join(' ');
 }

--- a/test/returnArray.js
+++ b/test/returnArray.js
@@ -1,0 +1,12 @@
+var shellescape = require('../');
+
+var assert = require('assert');
+
+var args = ['curl', '-v', '-H', 'Location;', '-H', 'User-Agent: dave#10', 'http://www.daveeddy.com/?name=dave&age=24'];
+
+var escaped = shellescape(args, {returnArray: true});
+
+var expected = ['curl', '-v', '-H', '\'Location;\'', '-H', '\'User-Agent: dave#10\'', '\'http://www.daveeddy.com/?name=dave&age=24\''];
+
+assert.deepEqual(escaped, expected);
+console.log(escaped);


### PR DESCRIPTION
I've added the ability to return the arguments array rather than string for use with Node.js child_process.spawn

``` js
var cp = require('child_process').spawn('ls', shellescape(['-la', '/tmp/my path'], {returnArray: true}));
```
